### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/demorelease.yml
+++ b/.github/workflows/demorelease.yml
@@ -56,8 +56,8 @@ jobs:
     
     - name: Github Release
       # You may pin to the exact commit or the version.
-      # uses: elgohr/Github-Release-Action@ed9ebd01a0c57e64e948e7f2ff59c0159e52c204
-      uses: elgohr/Github-Release-Action@v3.1
+      # uses: elgohr/Github-Release-Action@v4
+      uses: elgohr/Github-Release-Action@v4
       with:
         # The name of the release to publish
         args: ${{ steps.project.outputs.version }}


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore